### PR TITLE
Add test_all.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Or, if you want to be fancy:
 
 `time python -m cProfile -s time run.py cases/case0.json case0`
 
+Run some tests with `bash test_all.sh`.
+
 Usage is `python run.py case_name.json [output_name]`. If `output_name` is not provided, then it defaults to `"output"`. Two files are generated: `output_name.log` and `output_name.pdf`. `output_name.pdf` has graphs of all the stats.
 
 Conventions

--- a/run.py
+++ b/run.py
@@ -1,10 +1,7 @@
-import random
 import sys
 
 import globals_
 
-from event_manager import EventManager
-from stats_manager import StatsManager
 from file_parser import FileParser
 from main_setup import main_setup
 

--- a/stats_manager.py
+++ b/stats_manager.py
@@ -1,6 +1,7 @@
 import globals_
 
 from graph import Graph
+import matplotlib
 from matplotlib.backends.backend_pdf import PdfPages
 
 
@@ -13,6 +14,9 @@ class StatsManager(object):
     '''
 
     def __init__(self, output_name):
+        # Silence a warning
+        matplotlib.rcParams['figure.max_open_warning'] = 0
+
         self.graphs = dict()
         self.tag_count = 0
         if output_name is not None:

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,0 +1,14 @@
+echo "Running flake8"
+flake8 .
+
+echo "Running generate.sh"
+cd cases
+bash generate.sh > /dev/null
+
+cd ..
+echo "Running case0"
+time python run.py cases/case0.json case0_test_output 
+echo "Running case1"
+time python run.py cases/case1.json case1_test_output 
+echo "Running case2"
+time python run.py cases/case2.json case2_test_output


### PR DESCRIPTION
`bash test_all.sh` runs flake8, generate.sh, and run.py on each of the
three test cases.

Fix flake8 warnings.

Silence a matplotlib's max_open_figures warning.
