### PR TITLE
Fix: Travis no longer has graphviz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ ptyhon:
     - "2.7"
 
 install: 
-    - sudo apt-get install graphviz
     - pip install -r requirements.txt
 
 script: bash test_all.sh

--- a/cases/generate_without_dot.sh
+++ b/cases/generate_without_dot.sh
@@ -1,0 +1,18 @@
+# Generates case*.json files from case*.py files
+# Runs verify.py on the case*.json files
+# Does not generate DOT files. This is only intended to be useful for
+# continuous integration.v
+
+for c in case*.py
+do
+    json_filename=$(echo "$c" | sed s/\.py/\.json/)
+    dot_filename=$(echo "$c" | sed s/\.py/\.pdf/)
+    echo "Generating $json_filename"
+    python $c > $json_filename
+done
+
+for json_filename in case*.json
+do
+    echo "Checking $json_filename for obvious errors"
+    python ../check_json.py < $json_filename
+done


### PR DESCRIPTION
`sudo apt-get install graphviz` stopped working with message
"E: Package 'graphviz' has no installation candidate"
Broken build: https://travis-ci.org/AGFeldman/jaka/builds/95133174

This solution is just to remove the graphviz dependency from the CI test
