### PR TITLE
Remove randomness from simulation

### DIFF
--- a/event_manager.py
+++ b/event_manager.py
@@ -1,4 +1,3 @@
-import random
 import heapq
 import signal
 
@@ -82,7 +81,6 @@ class EventManager(object):
             keep_acting = True
             while keep_acting:
                 keep_acting = False
-                random.shuffle(self.actors)
                 for actor in self.actors:
                     if actor.act():
                         keep_acting = True

--- a/main_setup.py
+++ b/main_setup.py
@@ -1,5 +1,3 @@
-import random
-
 from event_manager import EventManager
 from stats_manager import StatsManager
 import globals_
@@ -9,11 +7,8 @@ def main_setup(output_name):
     '''
     This should be called at the beginning of main if you're running unit tests
     or simulations.
-    It seeds the random number generator and sets the global variable
-    |globals_.event_manager|.
     We need to set |globals_.event_manager| for most class definitions and helper
     functions to make sense.
     '''
-    random.seed(0)
     globals_.event_manager = EventManager(output_name)
     globals_.stats_manager = StatsManager(output_name)


### PR DESCRIPTION
Previously, randomness was used to determine which direction a link
sends, if the front packets on each of the buffers share the same age.
It seemed like this could lead to bad behavior. Now, if both directions
are tied in this way, the direction that sent least recently is chosen.

Also, actors are no longer shuffled by the event manager. So, there is
no randomness in the simulation.
